### PR TITLE
emptycase: allow to test this linter with external testdata

### DIFF
--- a/emptycase.go
+++ b/emptycase.go
@@ -1,9 +1,10 @@
 package emptycase
 
 import (
-	"github.com/gostaticanalysis/comment"
 	"go/ast"
 	"strings"
+
+	"github.com/gostaticanalysis/comment"
 
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/inspect"
@@ -16,53 +17,63 @@ const doc = "emptycase find empty cases"
 var Analyzer = &analysis.Analyzer{
 	Name: "emptycase",
 	Doc:  doc,
-	Run:  run,
+	Run:  run(false),
 	Requires: []*analysis.Analyzer{
 		inspect.Analyzer,
 	},
 }
 
-var analyzerTest = false
+// AnalyzerForTesting is ...
+var AnalyzerForTesting = &analysis.Analyzer{
+	Name: "emptycase",
+	Doc:  doc,
+	Run:  run(true),
+	Requires: []*analysis.Analyzer{
+		inspect.Analyzer,
+	},
+}
 
-func run(pass *analysis.Pass) (interface{}, error) {
-	commentMap := comment.New(pass.Fset, pass.Files)
+func run(analyzerTest bool) func(pass *analysis.Pass) (interface{}, error) {
+	return func(pass *analysis.Pass) (interface{}, error) {
+		commentMap := comment.New(pass.Fset, pass.Files)
 
-	// Report a case with no body.
-	// However, if a comment is attached to it, it is considered an intentional empty case and not reported.
-	var emptyCaseChecker = func(caseNode ast.Node, body []ast.Stmt) {
-		if len(body) != 0 {
-			return
-		}
+		// Report a case with no body.
+		// However, if a comment is attached to it, it is considered an intentional empty case and not reported.
+		var emptyCaseChecker = func(caseNode ast.Node, body []ast.Stmt) {
+			if len(body) != 0 {
+				return
+			}
 
-		commentGroup := commentMap.Comments(caseNode)
-		if len(commentGroup) == 0 {
-			pass.Reportf(caseNode.Pos(), "empty case")
-			return
-		}
-
-		if analyzerTest {
-			// Comments that indicate the expected value of the analyzer test are not considered comments.
-			if len(commentGroup) == 1 && strings.HasPrefix(strings.TrimLeft(commentGroup[0].List[0].Text[2:], " "), "want") {
+			commentGroup := commentMap.Comments(caseNode)
+			if len(commentGroup) == 0 {
 				pass.Reportf(caseNode.Pos(), "empty case")
+				return
+			}
+
+			if analyzerTest {
+				// Comments that indicate the expected value of the analyzer test are not considered comments.
+				if len(commentGroup) == 1 && strings.HasPrefix(strings.TrimLeft(commentGroup[0].List[0].Text[2:], " "), "want") {
+					pass.Reportf(caseNode.Pos(), "empty case")
+				}
 			}
 		}
-	}
 
-	inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+		inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
 
-	nodeFilter := []ast.Node{
-		(*ast.CaseClause)(nil),
-		(*ast.CommClause)(nil),
-	}
-
-	inspect.Preorder(nodeFilter, func(n ast.Node) {
-		switch n := n.(type) {
-		case *ast.CaseClause:
-			emptyCaseChecker(n, n.Body)
-		case *ast.CommClause:
-			emptyCaseChecker(n, n.Body)
+		nodeFilter := []ast.Node{
+			(*ast.CaseClause)(nil),
+			(*ast.CommClause)(nil),
 		}
-	})
 
-	return nil, nil
+		inspect.Preorder(nodeFilter, func(n ast.Node) {
+			switch n := n.(type) {
+			case *ast.CaseClause:
+				emptyCaseChecker(n, n.Body)
+			case *ast.CommClause:
+				emptyCaseChecker(n, n.Body)
+			}
+		})
+
+		return nil, nil
+	}
 }

--- a/emptycase_test.go
+++ b/emptycase_test.go
@@ -10,6 +10,5 @@ import (
 // TestAnalyzer is a analyzerTest for Analyzer.
 func TestAnalyzer(t *testing.T) {
 	testdata := testutil.WithModules(t, analysistest.TestData(), nil)
-	analyzerTest = true
-	analysistest.Run(t, testdata, Analyzer, "a")
+	analysistest.Run(t, testdata, AnalyzerForTesting, "a")
 }


### PR DESCRIPTION
I'm about to include this linter inside golangci-lint which tests each linter internally using "want" comments.
This change allows such usage.